### PR TITLE
fix image for external-dns

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -6,7 +6,7 @@ parameters:
     images:
       externaldns:
         registry: k8s.gcr.io
-        image: external-dns
+        image: external-dns/external-dns
         tag: v0.8.0
 
     provider: ${facts:cloud}


### PR DESCRIPTION
the image name was not correnctly set, its full image name is `k8s.gcr.io/external-dns/external-dns:v0.8.0`

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
